### PR TITLE
HTTP 429 errors trigger reconnect

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "sse-client"
-version = "1.1.2"
+version = "1.1.3"
 authors = ["Vinicius Gerevini <viniciusgerevini@gmail.com>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/viniciusgerevini/sse-client"
 description = "Client for streams of Server-Sent Events"
 keywords = ["sse", "event-source", "http", "client"]
+edition = "2018"
 
 [features]
 default = []
@@ -16,6 +17,7 @@ native-tls-vendored = ["native-tls", "native-tls-crate/vendored"]
 [dependencies]
 url = "1.7.0"
 native-tls-crate = { package = "native-tls", version = "0.2.3", optional = true }
+rand = "0.7.3"
 
 [dev-dependencies]
 http-test-server = "1.0.0"

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "native-tls")]
 use crate::tls::MaybeTlsStream;
+use rand::{thread_rng, Rng};
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::io::Error;
@@ -409,7 +410,9 @@ fn reconnect_stream(
 ) {
     let mut attempts = failed_attempts.lock().unwrap();
     let base: u64 = 2;
-    let reconnection_time = INITIAL_RECONNECTION_TIME_IN_MS + (15 * (base.pow(*attempts) - 1));
+    let mut rng = thread_rng();
+    let n: u64 = rng.gen_range(1, 99);
+    let reconnection_time = INITIAL_RECONNECTION_TIME_IN_MS + (n * (base.pow(*attempts) - 1));
     *attempts += 1;
 
     thread::sleep(Duration::from_millis(reconnection_time));


### PR DESCRIPTION
HTTP 429 (Too many requests) are often generated when trying to reconnect several event sources to a given endpoint at once. This can happen after the endpoint experiences an outage forcing all event sources to reconnect when it becomes available again.

- Attempt to reconnect when an http/429 error is returned
- Include a random coefficient into the reconnection backoff calculation to stagger connection attempts
